### PR TITLE
use CommonJS and add empty .npmignore for compatibility (with Node and Yarn respectively)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "target": "ES2015",
-        "module": "ES2015",
+        "module": "CommonJS",
         "moduleResolution": "node",
         "declaration": true,
         "outDir": "lib/",


### PR DESCRIPTION
Switched to CommonJS because, even after setting the type to module in `package.json`, Node didn't like the Typescript-generated ES2015 imports and exports in `index.js` cause they weren't fully qualified (missing the `.js`s):
- ["You need to use fully-qualified imports when feeding ES6 modules to Node.js." ~ ELLIOTTCABLE](https://stackoverflow.com/a/65975356)
- ["The browser needs requires fully qualified import paths and Typescript doesn't convert the import extension during compilation." "The only way to achieve this at the moment is to use `.js` in your TypeScript imports (even though the file is technically `.ts`)."](https://stackoverflow.com/a/51524829)
- ["Provide a way to add the '.js' file extension to the end of module specifiers" "We are not going to implement features, even under a commandline flag, that imply changing JS semantics by rewriting it during emit"](https://github.com/Microsoft/TypeScript/issues/16577)

Added the empty `.npmignore` so that Yarn wouldn't remove the files generated from the prepare script:
- ["Installing npm package with prepare script from yarn produces only index.js" "Finally found a solution - the trick is to add empty .npmignore file to the repository."](https://stackoverflow.com/a/61760051)
- ["Lifecycle scripts for hosted git and local dependencies not run on install"](https://github.com/yarnpkg/yarn/issues/5235)

Also when using this repository as a dependency through Yarn, for some horrific reason, the prepare script didn't run correctly for Noah, and `yarn install` just straight up threw [an error](https://stackoverflow.com/questions/70663523/the-unauthenticated-git-protocol-on-port-9418-is-no-longer-supported) for me until we both switched the dependency value to...
```
"pvs-breath-pacer": "https://github.com/EmotionCognitionLab/pvs-breath-pacer.git#commonjs"
```
Yup. Noah started from `github:EmotionCognitionLab/pvs-breath-pacer#commonjs`, I started from `git://github.com/EmotionCognitionLab/pvs-breath-pacer.git#commonjs`, and [both our problems went away went we switched to `https`](https://stackoverflow.com/a/70667683).

Truly unfathomable.